### PR TITLE
Fixed negative money support

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/widget/ui/PriceInputEditText.kt
+++ b/app/src/main/java/co/smartreceipts/android/widget/ui/PriceInputEditText.kt
@@ -6,9 +6,8 @@ import android.text.InputType
 import android.text.method.DigitsKeyListener
 import android.util.AttributeSet
 import android.view.inputmethod.EditorInfo
-import androidx.appcompat.R
 import androidx.appcompat.widget.AppCompatEditText
-import co.smartreceipts.analytics.log.Logger.debug
+import co.smartreceipts.android.R
 import co.smartreceipts.android.model.Price
 import co.smartreceipts.android.model.utils.ModelUtils
 import com.jakewharton.rxbinding3.widget.afterTextChangeEvents
@@ -31,18 +30,46 @@ class PriceInputEditText @JvmOverloads constructor(
 
         imeOptions = EditorInfo.IME_ACTION_NEXT or EditorInfo.IME_FLAG_NO_EXTRACT_UI
 
-        keyListener = DigitsKeyListener.getInstance("0123456789${ModelUtils.decimalSeparator}")
+        setKeyListenerWithDecimalSeparator()
 
         this.afterTextChangeEvents()
             .map { it.editable }
             .filter { !it.isNullOrEmpty() }
-            .subscribe {editable: Editable? ->
-                // don't allow to input more decimal separators than one (this is not handled by Android for ',')
-                val text = editable.toString()
-                val decimalSeparator = ModelUtils.decimalSeparator
-                if (text.indexOf(decimalSeparator) != text.lastIndexOf(decimalSeparator)) {
-                    setText(text.dropLast(text.length - text.lastIndexOf(decimalSeparator)))
-                    setSelection(length())
+            .subscribe { editable: Editable? ->
+                val correctDecimalSeparator = ModelUtils.decimalSeparator
+                val incorrectDecimalSeparator = if (correctDecimalSeparator == '.') ',' else '.'
+
+                val originalText = editable.toString()
+                var correctedText = originalText
+
+                var lastSelectionPosition = selectionStart
+
+                val isDecimalSeparatorPresent = originalText.contains('.', true) || originalText.contains(',', true)
+                if (isDecimalSeparatorPresent) {
+                    setKeyListenerWithoutDecimalSeparator()
+                    // due to some specific keyboard behavior (Samsung KitKat users don't have ',') we need to allow user to input any decimal separator
+                    // but then correct it if it's not location-based
+                    if (originalText.contains(incorrectDecimalSeparator, true)) {
+                        correctedText = originalText.replace(incorrectDecimalSeparator, correctDecimalSeparator, true)
+                    }
+                } else {
+                    setKeyListenerWithDecimalSeparator()
+                }
+
+                // allowed to input '-' just once at the start of the string, all other '-'s will be removed
+                if (originalText.indexOf('-', 1) != -1) {
+                    // found extra minus, need to remove it
+                    val substring = correctedText.substring(1)
+                    val extraMinusesCount = substring.filter { it == '-' }.count()
+
+                    correctedText = correctedText[0] + substring.replace("-", "")
+                    lastSelectionPosition -= extraMinusesCount
+                }
+
+                // update text and cursor position if needed
+                if (correctedText != originalText) {
+                    setText(correctedText)
+                    setSelection(0.coerceAtLeast(lastSelectionPosition))
                 }
             }
     }
@@ -65,5 +92,12 @@ class PriceInputEditText @JvmOverloads constructor(
         setSelection(formatted.length)
     }
 
+    private fun setKeyListenerWithDecimalSeparator() {
+        keyListener = DigitsKeyListener.getInstance("-0123456789.,")
+    }
+
+    private fun setKeyListenerWithoutDecimalSeparator() {
+        keyListener = DigitsKeyListener.getInstance("-0123456789")
+    }
 
 }

--- a/app/src/test/java/co/smartreceipts/android/model/impl/MultiplePriceImplTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/model/impl/MultiplePriceImplTest.kt
@@ -32,6 +32,7 @@ class MultiplePriceImplTest {
 
 
     private lateinit var sameCurrencyPrice: MultiplePriceImpl
+    private lateinit var sameCurrencyWithNegativePrice: MultiplePriceImpl
     private lateinit var differentCurrenciesNoExchangeRatePrice: MultiplePriceImpl
     private lateinit var differentCurrenciesWithExchangeRatePrice: MultiplePriceImpl
 
@@ -40,23 +41,18 @@ class MultiplePriceImplTest {
     fun setUp() {
         TestLocaleToggler.setDefaultLocale(Locale.US)
 
-        val priceUsd1 =
-            SinglePriceImpl(BigDecimal.ONE, USD_CURRENCY, USD_EXCHANGE_RATE)
-        val priceUsd2 =
-            SinglePriceImpl(BigDecimal(2.0), USD_CURRENCY, USD_EXCHANGE_RATE)
+        val priceUsd1 = SinglePriceImpl(BigDecimal.ONE, USD_CURRENCY, USD_EXCHANGE_RATE)
+        val priceUsd2 = SinglePriceImpl(BigDecimal(2.0), USD_CURRENCY, USD_EXCHANGE_RATE)
+        val priceUsd2Negative = SinglePriceImpl(BigDecimal(-2.0), USD_CURRENCY, USD_EXCHANGE_RATE)
 
-        val priceEur1 =
-            SinglePriceImpl(BigDecimal.ONE, EUR_CURRENCY, EUR_EXCHANGE_RATE)
+        val priceEur1 = SinglePriceImpl(BigDecimal.ONE, EUR_CURRENCY, EUR_EXCHANGE_RATE)
 
-        val priceJpu1 =
-            SinglePriceImpl(BigDecimal.ONE, JPY_CURRENCY, JPY_EXCHANGE_RATE)
+        val priceJpu1 = SinglePriceImpl(BigDecimal.ONE, JPY_CURRENCY, JPY_EXCHANGE_RATE)
 
-        sameCurrencyPrice =
-            MultiplePriceImpl(USD_CURRENCY, listOf(priceUsd1, priceUsd2))
-        differentCurrenciesWithExchangeRatePrice =
-            MultiplePriceImpl(USD_CURRENCY, listOf(priceUsd1, priceUsd2, priceEur1))
-        differentCurrenciesNoExchangeRatePrice =
-            MultiplePriceImpl(USD_CURRENCY, listOf(priceUsd1, priceEur1, priceJpu1))
+        sameCurrencyPrice = MultiplePriceImpl(USD_CURRENCY, listOf(priceUsd1, priceUsd2))
+        sameCurrencyWithNegativePrice = MultiplePriceImpl(USD_CURRENCY, listOf(priceUsd1, priceUsd2Negative))
+        differentCurrenciesWithExchangeRatePrice = MultiplePriceImpl(USD_CURRENCY, listOf(priceUsd1, priceUsd2, priceEur1))
+        differentCurrenciesNoExchangeRatePrice = MultiplePriceImpl(USD_CURRENCY, listOf(priceUsd1, priceEur1, priceJpu1))
     }
 
     @After
@@ -67,6 +63,7 @@ class MultiplePriceImplTest {
     @Test
     fun getPriceAsFloat() {
         assertEquals(3f, sameCurrencyPrice.priceAsFloat, TestUtils.EPSILON)
+        assertEquals(-1f, sameCurrencyWithNegativePrice.priceAsFloat, TestUtils.EPSILON)
         assertEquals(5f, differentCurrenciesWithExchangeRatePrice.priceAsFloat, TestUtils.EPSILON)
         assertEquals(4f, differentCurrenciesNoExchangeRatePrice.priceAsFloat, TestUtils.EPSILON)
     }
@@ -74,6 +71,7 @@ class MultiplePriceImplTest {
     @Test
     fun getPrice() {
         assertEquals(3.0, sameCurrencyPrice.price.toDouble(), TestUtils.EPSILON.toDouble())
+        assertEquals(-1.0, sameCurrencyWithNegativePrice.price.toDouble(), TestUtils.EPSILON.toDouble())
         assertEquals(5.0, differentCurrenciesWithExchangeRatePrice.price.toDouble(), TestUtils.EPSILON.toDouble())
         assertEquals(4.0, differentCurrenciesNoExchangeRatePrice.price.toDouble(), TestUtils.EPSILON.toDouble())
     }
@@ -81,6 +79,7 @@ class MultiplePriceImplTest {
     @Test
     fun getDecimalFormattedPrice() {
         assertEquals("3.00", sameCurrencyPrice.decimalFormattedPrice)
+        assertEquals("-1.00", sameCurrencyWithNegativePrice.decimalFormattedPrice)
         assertEquals("5.00", differentCurrenciesWithExchangeRatePrice.decimalFormattedPrice)
         assertEquals("JPY 1; USD 3.00", differentCurrenciesNoExchangeRatePrice.decimalFormattedPrice)
     }
@@ -88,6 +87,7 @@ class MultiplePriceImplTest {
     @Test
     fun getCurrencyFormattedPrice() {
         assertEquals("$3.00", sameCurrencyPrice.currencyFormattedPrice)
+        assertEquals("$-1.00", sameCurrencyWithNegativePrice.currencyFormattedPrice)
         assertEquals("$5.00", differentCurrenciesWithExchangeRatePrice.currencyFormattedPrice)
         assertEquals("JPY1; $3.00", differentCurrenciesNoExchangeRatePrice.currencyFormattedPrice)
     }
@@ -95,6 +95,7 @@ class MultiplePriceImplTest {
     @Test
     fun getCurrencyCodeFormattedPrice() {
         assertEquals("USD 3.00", sameCurrencyPrice.currencyCodeFormattedPrice)
+        assertEquals("USD -1.00", sameCurrencyWithNegativePrice.currencyCodeFormattedPrice)
         assertEquals("EUR 1.00; USD 3.00", differentCurrenciesWithExchangeRatePrice.currencyCodeFormattedPrice)
         assertEquals("JPY 1; EUR 1.00; USD 1.00", differentCurrenciesNoExchangeRatePrice.currencyCodeFormattedPrice)
     }
@@ -102,6 +103,7 @@ class MultiplePriceImplTest {
     @Test
     fun getCurrency() {
         assertEquals(USD_CURRENCY, sameCurrencyPrice.currency)
+        assertEquals(USD_CURRENCY, sameCurrencyWithNegativePrice.currency)
         assertEquals(USD_CURRENCY, differentCurrenciesNoExchangeRatePrice.currency)
         assertEquals(USD_CURRENCY, differentCurrenciesWithExchangeRatePrice.currency)
     }
@@ -109,6 +111,7 @@ class MultiplePriceImplTest {
     @Test
     fun getCurrencyCode() {
         assertEquals(USD_CURRENCY.code, sameCurrencyPrice.currencyCode)
+        assertEquals(USD_CURRENCY.code, sameCurrencyWithNegativePrice.currencyCode)
         assertEquals(String.format("%s; %s", EUR_CURRENCY.code, USD_CURRENCY.code), differentCurrenciesWithExchangeRatePrice.currencyCode)
         assertEquals(
             String.format("%s; %s; %s", JPY_CURRENCY.code, EUR_CURRENCY.code, USD_CURRENCY.code),
@@ -119,6 +122,7 @@ class MultiplePriceImplTest {
     @Test
     fun isSingleCurrency() {
         assertEquals(true, sameCurrencyPrice.isSingleCurrency)
+        assertEquals(true, sameCurrencyWithNegativePrice.isSingleCurrency)
         assertEquals(false, differentCurrenciesNoExchangeRatePrice.isSingleCurrency)
         assertEquals(false, differentCurrenciesWithExchangeRatePrice.isSingleCurrency)
     }
@@ -126,6 +130,7 @@ class MultiplePriceImplTest {
     @Test
     fun testToString() {
         assertEquals("$3.00", sameCurrencyPrice.currencyFormattedPrice)
+        assertEquals("$-1.00", sameCurrencyWithNegativePrice.currencyFormattedPrice)
         assertEquals("$5.00", differentCurrenciesWithExchangeRatePrice.currencyFormattedPrice)
         assertEquals("JPY1; $3.00", differentCurrenciesNoExchangeRatePrice.currencyFormattedPrice)
     }
@@ -158,6 +163,15 @@ class MultiplePriceImplTest {
         val parcelPrice3 = MultiplePriceImpl.CREATOR.createFromParcel(parcel3)
         assertNotNull(parcelPrice3)
         assertEquals(differentCurrenciesWithExchangeRatePrice, parcelPrice3)
+
+        // Test negative
+        val parcelNegative = Parcel.obtain()
+        sameCurrencyWithNegativePrice.writeToParcel(parcelNegative, 0)
+        parcelNegative.setDataPosition(0)
+
+        val parcelPriceNegative = MultiplePriceImpl.CREATOR.createFromParcel(parcelNegative)
+        assertNotNull(parcelPriceNegative)
+        assertEquals(sameCurrencyWithNegativePrice, parcelPriceNegative)
     }
 
     @Test
@@ -165,10 +179,8 @@ class MultiplePriceImplTest {
         val usd1 = SinglePriceImpl(BigDecimal.ONE, USD_CURRENCY, USD_EXCHANGE_RATE)
         val usd2 = SinglePriceImpl(BigDecimal(2), USD_CURRENCY, USD_EXCHANGE_RATE)
         val usd0 = SinglePriceImpl(BigDecimal.ZERO, USD_CURRENCY, USD_EXCHANGE_RATE)
-        val eur3 =
-            SinglePriceImpl(BigDecimal(3), CurrencyUnit.EUR, EUR_EXCHANGE_RATE)
-        val eur1 =
-            SinglePriceImpl(BigDecimal.ONE, CurrencyUnit.EUR, EUR_EXCHANGE_RATE)
+        val eur3 = SinglePriceImpl(BigDecimal(3), CurrencyUnit.EUR, EUR_EXCHANGE_RATE)
+        val eur1 = SinglePriceImpl(BigDecimal.ONE, CurrencyUnit.EUR, EUR_EXCHANGE_RATE)
 
         val equalPrice = MultiplePriceImpl(USD_CURRENCY, listOf(usd1, usd2))
 
@@ -178,11 +190,13 @@ class MultiplePriceImplTest {
         assertEquals(sameCurrencyPrice, sameCurrencyPrice)
         assertEquals(sameCurrencyPrice, equalPriceWithEur)
         assertEquals(sameCurrencyPrice, equalPrice)
-        assertEquals(sameCurrencyPrice,
+        assertEquals(
+            sameCurrencyPrice,
             SinglePriceImpl(BigDecimal(3), USD_CURRENCY, USD_EXCHANGE_RATE)
         )
 
         assertNotEquals(differentCurrenciesNoExchangeRatePrice, sameCurrencyPrice)
+        assertNotEquals(sameCurrencyWithNegativePrice, sameCurrencyPrice)
         assertNotEquals(Any(), sameCurrencyPrice)
         assertNotEquals(usd0, sameCurrencyPrice)
         assertNotEquals(eur3, sameCurrencyPrice)

--- a/app/src/test/java/co/smartreceipts/android/model/impl/SinglePriceImplTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/model/impl/SinglePriceImplTest.kt
@@ -21,6 +21,7 @@ class SinglePriceImplTest {
 
         private const val PRICE_FLOAT = 1.2511f
         private val PRICE = BigDecimal(PRICE_FLOAT.toDouble())
+        private val PRICE_NEGATIVE = BigDecimal(PRICE_FLOAT * -1.0)
         private val CURRENCY1 = CurrencyUnit.USD // currency with 2 decimal places
         private val CURRENCY2 = CurrencyUnit.of("BHD") // currency with 3 decimal places
         private val CURRENCY3 = CurrencyUnit.JPY // currency with 0 decimal places
@@ -30,12 +31,14 @@ class SinglePriceImplTest {
     private lateinit var price1: SinglePriceImpl
     private lateinit var price2: SinglePriceImpl
     private lateinit var price3: SinglePriceImpl
+    private lateinit var priceNegative: SinglePriceImpl
 
     @Before
     fun setUp() {
         price1 = SinglePriceImpl(PRICE, CURRENCY1, EXCHANGE_RATE)
         price2 = SinglePriceImpl(PRICE, CURRENCY2, EXCHANGE_RATE)
         price3 = SinglePriceImpl(PRICE, CURRENCY3, EXCHANGE_RATE)
+        priceNegative = SinglePriceImpl(PRICE_NEGATIVE, CURRENCY1, EXCHANGE_RATE)
     }
 
     @Test
@@ -43,6 +46,7 @@ class SinglePriceImplTest {
         assertEquals(1.25f, price1.priceAsFloat)
         assertEquals(1.251f, price2.priceAsFloat)
         assertEquals(1f, price3.priceAsFloat)
+        assertEquals(-1.25f, priceNegative.priceAsFloat)
     }
 
     @Test
@@ -50,6 +54,7 @@ class SinglePriceImplTest {
         assertEquals(PRICE.setScale(2, RoundingMode.HALF_EVEN), price1.money.amount)
         assertEquals(PRICE.setScale(3, RoundingMode.HALF_EVEN), price2.money.amount)
         assertEquals(PRICE.setScale(0, RoundingMode.HALF_EVEN), price3.money.amount)
+        assertEquals(PRICE_NEGATIVE.setScale(2, RoundingMode.HALF_EVEN), priceNegative.money.amount)
     }
 
     @Test
@@ -57,6 +62,7 @@ class SinglePriceImplTest {
         assertEquals("1.25", price1.decimalFormattedPrice)
         assertEquals("1.251", price2.decimalFormattedPrice)
         assertEquals("1", price3.decimalFormattedPrice)
+        assertEquals("-1.25", priceNegative.decimalFormattedPrice)
     }
 
     @Test
@@ -64,6 +70,7 @@ class SinglePriceImplTest {
         assertEquals("$1.25", price1.currencyFormattedPrice)
         assertEquals("BHD1.251", price2.currencyFormattedPrice)
         assertEquals("JPY1", price3.currencyFormattedPrice)
+        assertEquals("$-1.25", priceNegative.currencyFormattedPrice)
     }
 
     @Test
@@ -71,11 +78,13 @@ class SinglePriceImplTest {
         assertEquals("USD 1.25", price1.currencyCodeFormattedPrice)
         assertEquals("BHD 1.251", price2.currencyCodeFormattedPrice)
         assertEquals("JPY 1", price3.currencyCodeFormattedPrice)
+        assertEquals("USD -1.25", priceNegative.currencyCodeFormattedPrice)
     }
 
     @Test
     fun getCurrency() {
         assertEquals(CURRENCY1, price1.currency)
+        assertEquals(CURRENCY1, priceNegative.currency)
         assertEquals(CURRENCY2, price2.currency)
         assertEquals(CURRENCY3, price3.currency)
     }
@@ -83,6 +92,7 @@ class SinglePriceImplTest {
     @Test
     fun getCurrencyCode() {
         assertEquals("USD", price1.currencyCode)
+        assertEquals("USD", priceNegative.currencyCode)
         assertEquals("BHD", price2.currencyCode)
         assertEquals("JPY", price3.currencyCode)
     }
@@ -92,6 +102,7 @@ class SinglePriceImplTest {
         assertEquals(true, price1.isSingleCurrency)
         assertEquals(true, price2.isSingleCurrency)
         assertEquals(true, price3.isSingleCurrency)
+        assertEquals(true, priceNegative.isSingleCurrency)
     }
 
     @Test
@@ -99,11 +110,13 @@ class SinglePriceImplTest {
         assertEquals(EXCHANGE_RATE, price1.exchangeRate)
         assertEquals(EXCHANGE_RATE, price2.exchangeRate)
         assertEquals(EXCHANGE_RATE, price3.exchangeRate)
+        assertEquals(EXCHANGE_RATE, priceNegative.exchangeRate)
     }
 
     @Test
     fun testToString() {
         assertEquals("$1.25", price1.toString())
+        assertEquals("$-1.25", priceNegative.toString())
         assertEquals("BHD1.251", price2.toString())
         assertEquals("JPY1", price3.toString())
     }
@@ -125,6 +138,7 @@ class SinglePriceImplTest {
         assertEquals(price1, SinglePriceImpl(PRICE, CURRENCY1, EXCHANGE_RATE))
 
         assertNotEquals(Any(), price1)
+        assertNotEquals(priceNegative, price1)
         assertNotEquals(mock(Distance::class.java), price1)
         assertNotEquals(SinglePriceImpl(BigDecimal.ZERO, CURRENCY1, EXCHANGE_RATE), price1)
         assertNotEquals(SinglePriceImpl(PRICE, CurrencyUnit.EUR, EXCHANGE_RATE), price1)

--- a/app/src/test/java/co/smartreceipts/android/model/utils/ModelUtilsTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/model/utils/ModelUtilsTest.kt
@@ -32,17 +32,20 @@ class ModelUtilsTest {
     @Test
     fun getDecimalFormattedValueForBigDecimal() {
         assertEquals("2.54", ModelUtils.getDecimalFormattedValue(BigDecimal(2.54)))
+        assertEquals("-2.54", ModelUtils.getDecimalFormattedValue(BigDecimal(-2.54)))
     }
 
     @Test
     fun getDecimalFormattedValueWithPrecision() {
         assertEquals("2.541", ModelUtils.getDecimalFormattedValue(BigDecimal(2.5412), 3))
         assertEquals("2.5", ModelUtils.getDecimalFormattedValue(BigDecimal(2.5412), 1))
+        assertEquals("-2.5", ModelUtils.getDecimalFormattedValue(BigDecimal(-2.5412), 1))
     }
 
     @Test
     fun getCurrencyFormattedValue() {
         assertEquals("$2.54", ModelUtils.getCurrencyFormattedValue(BigDecimal(2.54), currency))
+        assertEquals("$-2.54", ModelUtils.getCurrencyFormattedValue(BigDecimal(-2.54), currency))
         assertEquals("$2.5", ModelUtils.getCurrencyFormattedValue(BigDecimal(2.54), currency, 1))
         assertEquals("$2.540", ModelUtils.getCurrencyFormattedValue(BigDecimal(2.54), currency, 3))
     }
@@ -50,6 +53,7 @@ class ModelUtilsTest {
     @Test
     fun getCurrencyCodeFormattedValue() {
         assertEquals("USD 2.54", ModelUtils.getCurrencyCodeFormattedValue(BigDecimal(2.54), currency))
+        assertEquals("USD -2.54", ModelUtils.getCurrencyCodeFormattedValue(BigDecimal(-2.54), currency))
         assertEquals("USD 2.5", ModelUtils.getCurrencyCodeFormattedValue(BigDecimal(2.54), currency, 1))
         assertEquals("USD 2.540", ModelUtils.getCurrencyCodeFormattedValue(BigDecimal(2.54), currency, 3))
     }
@@ -61,11 +65,13 @@ class ModelUtilsTest {
 
         TestLocaleToggler.setDefaultLocale(Locale.US)
         assertTrue(ModelUtils.tryParse("2.00").compareTo(BigDecimal("2.00")) == 0)
+        assertTrue(ModelUtils.tryParse("-2.00").compareTo(BigDecimal("-2.00")) == 0)
         assertTrue(ModelUtils.tryParse("1,050,555.256").compareTo(BigDecimal("1050555.256")) == 0)
         assertTrue(ModelUtils.tryParse("1050555.256").compareTo(BigDecimal("1050555.256")) == 0)
 
         TestLocaleToggler.setDefaultLocale(Locale.FRANCE)
         assertTrue(ModelUtils.tryParse("2,00").compareTo(BigDecimal("2.00")) == 0)
+        assertTrue(ModelUtils.tryParse("-2,00").compareTo(BigDecimal("-2.00")) == 0)
         assertTrue(ModelUtils.tryParse("1 050 555,256").compareTo(BigDecimal("1050555.256")) == 0)
         assertTrue(ModelUtils.tryParse("105 0555,256").compareTo(BigDecimal("1050555.256")) == 0)
     }


### PR DESCRIPTION
We've lost negative prices amount support recently after including JodaMoney due to not quite correct implementation of `PriceInputEditText`.

Now `PriceInputEditText` is fixed. Also, added negative price testing.