### PR TITLE
Fixed interstitial ads for free app version with plus subscription

### DIFF
--- a/app/src/free/java/co/smartreceipts/android/ad/AdMobInterstitialAdPresenter.kt
+++ b/app/src/free/java/co/smartreceipts/android/ad/AdMobInterstitialAdPresenter.kt
@@ -3,6 +3,8 @@ package co.smartreceipts.android.ad
 import android.content.Context
 import co.smartreceipts.analytics.log.Logger
 import co.smartreceipts.android.R
+import co.smartreceipts.android.purchases.model.InAppPurchase
+import co.smartreceipts.android.purchases.wallet.PurchaseWallet
 import co.smartreceipts.core.di.scopes.ApplicationScope
 import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.AdRequest
@@ -10,7 +12,8 @@ import com.google.android.gms.ads.InterstitialAd
 import javax.inject.Inject
 
 @ApplicationScope
-class AdMobInterstitialAdPresenter @Inject constructor(context: Context) : InterstitialAdPresenter {
+class AdMobInterstitialAdPresenter @Inject constructor(context: Context, private val purchaseWallet: PurchaseWallet) :
+    InterstitialAdPresenter {
 
     private var interstitialAd: InterstitialAd = InterstitialAd(context)
 
@@ -31,6 +34,10 @@ class AdMobInterstitialAdPresenter @Inject constructor(context: Context) : Inter
     }
 
     override fun showAd() {
+        if (purchaseWallet.hasActivePurchase(InAppPurchase.SmartReceiptsPlus)) {
+            return
+        }
+
         if (interstitialAd.isLoaded) {
             interstitialAd.show()
         } else when {


### PR DESCRIPTION
Small fix to disable interstitial ads for users of the Smart Receipts free application with plus in-app subscription