### PR TITLE
Fix for ArrayIndexOutOfBoundsException

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/distance/editor/DistanceCreateEditFragment.kt
+++ b/app/src/main/java/co/smartreceipts/android/distance/editor/DistanceCreateEditFragment.kt
@@ -425,22 +425,26 @@ class DistanceCreateEditFragment : WBFragment(), DistanceCreateEditView, View.On
 
     override fun removeValueFromAutoComplete(position: Int) {
         activity!!.runOnUiThread {
-            itemToRemoveOrReAdd = resultsAdapter.getItem(position)
-            resultsAdapter.remove(itemToRemoveOrReAdd)
-            resultsAdapter.notifyDataSetChanged()
-            val view = activity!!.findViewById<ConstraintLayout>(R.id.update_distance_layout)
-            snackbar = Snackbar.make(view, getString(
-                    R.string.item_removed_from_auto_complete, itemToRemoveOrReAdd!!.displayName), Snackbar.LENGTH_LONG)
-            snackbar.setAction(R.string.undo) {
-                if (text_distance_location.hasFocus()) {
-                    _unHideAutoCompleteVisibilityClicks.onNext(
-                            AutoCompleteUpdateEvent(itemToRemoveOrReAdd, DistanceAutoCompleteField.Location, position))
-                } else {
-                    _unHideAutoCompleteVisibilityClicks.onNext(
-                            AutoCompleteUpdateEvent(itemToRemoveOrReAdd, DistanceAutoCompleteField.Comment, position))
+            if (position in 0 until resultsAdapter.count) {
+                itemToRemoveOrReAdd = resultsAdapter.getItem(position)
+                resultsAdapter.remove(itemToRemoveOrReAdd)
+                resultsAdapter.notifyDataSetChanged()
+                val view = activity!!.findViewById<ConstraintLayout>(R.id.update_distance_layout)
+                snackbar = Snackbar.make(view, getString(
+                        R.string.item_removed_from_auto_complete, itemToRemoveOrReAdd!!.displayName), Snackbar.LENGTH_LONG)
+                snackbar.setAction(R.string.undo) {
+                    if (text_distance_location.hasFocus()) {
+                        _unHideAutoCompleteVisibilityClicks.onNext(
+                            AutoCompleteUpdateEvent(itemToRemoveOrReAdd, DistanceAutoCompleteField.Location, position)
+                        )
+                    } else {
+                        _unHideAutoCompleteVisibilityClicks.onNext(
+                            AutoCompleteUpdateEvent(itemToRemoveOrReAdd, DistanceAutoCompleteField.Comment, position)
+                        )
+                    }
                 }
+                snackbar.show()
             }
-            snackbar.show()
         }
     }
 

--- a/app/src/main/java/co/smartreceipts/android/receipts/editor/ReceiptCreateEditFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/receipts/editor/ReceiptCreateEditFragment.java
@@ -1056,22 +1056,24 @@ public class ReceiptCreateEditFragment extends WBFragment implements Editor<Rece
     @Override
     public void removeValueFromAutoComplete(int position) {
         getActivity().runOnUiThread(() -> {
-            itemToRemoveOrReAdd = resultsAdapter.getItem(position);
-            resultsAdapter.remove(itemToRemoveOrReAdd);
-            resultsAdapter.notifyDataSetChanged();
-            View view = getActivity().findViewById(R.id.update_receipt_layout);
-            snackbar = Snackbar.make(view, getString(
-                    R.string.item_removed_from_auto_complete, itemToRemoveOrReAdd.getDisplayName()), Snackbar.LENGTH_LONG);
-            snackbar.setAction(R.string.undo, v -> {
-                if (nameBox.hasFocus()) {
-                    _unHideAutoCompleteVisibilityClicks.onNext(
-                            new AutoCompleteUpdateEvent(itemToRemoveOrReAdd, ReceiptAutoCompleteField.Name, position));
-                } else {
-                    _unHideAutoCompleteVisibilityClicks.onNext(
-                            new AutoCompleteUpdateEvent(itemToRemoveOrReAdd, ReceiptAutoCompleteField.Comment, position));
-                }
-            });
-            snackbar.show();
+            if (position >= 0 && position < resultsAdapter.getCount()) {
+                itemToRemoveOrReAdd = resultsAdapter.getItem(position);
+                resultsAdapter.remove(itemToRemoveOrReAdd);
+                resultsAdapter.notifyDataSetChanged();
+                View view = getActivity().findViewById(R.id.update_receipt_layout);
+                snackbar = Snackbar.make(view, getString(
+                        R.string.item_removed_from_auto_complete, itemToRemoveOrReAdd.getDisplayName()), Snackbar.LENGTH_LONG);
+                snackbar.setAction(R.string.undo, v -> {
+                    if (nameBox.hasFocus()) {
+                        _unHideAutoCompleteVisibilityClicks.onNext(
+                                new AutoCompleteUpdateEvent(itemToRemoveOrReAdd, ReceiptAutoCompleteField.Name, position));
+                    } else {
+                        _unHideAutoCompleteVisibilityClicks.onNext(
+                                new AutoCompleteUpdateEvent(itemToRemoveOrReAdd, ReceiptAutoCompleteField.Comment, position));
+                    }
+                });
+                snackbar.show();
+            }
         });
     }
 

--- a/app/src/main/java/co/smartreceipts/android/trips/editor/TripCreateEditFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/trips/editor/TripCreateEditFragment.java
@@ -24,13 +24,11 @@ import com.jakewharton.rxbinding2.widget.RxDateEditText;
 import com.jakewharton.rxbinding3.widget.RxTextView;
 
 import org.jetbrains.annotations.NotNull;
-import org.joda.money.CurrencyUnit;
 
 import java.sql.Date;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
@@ -591,22 +589,24 @@ public class TripCreateEditFragment extends WBFragment implements Editor<Trip>,
     @Override
     public void removeValueFromAutoComplete(int position) {
         getActivity().runOnUiThread(() -> {
-            itemToRemoveOrReAdd = resultsAdapter.getItem(position);
-            resultsAdapter.remove(itemToRemoveOrReAdd);
-            resultsAdapter.notifyDataSetChanged();
-            View view = getActivity().findViewById(R.id.update_trip_layout);
-            snackbar = Snackbar.make(view, getString(
-                    R.string.item_removed_from_auto_complete, itemToRemoveOrReAdd.getDisplayName()), Snackbar.LENGTH_LONG);
-            snackbar.setAction(R.string.undo, v -> {
-                if (nameBox.hasFocus()) {
-                    _unHideAutoCompleteVisibilityClicks.onNext(new AutoCompleteUpdateEvent(itemToRemoveOrReAdd, TripAutoCompleteField.Name, position));
-                } else if (commentBox.hasFocus()) {
-                    _unHideAutoCompleteVisibilityClicks.onNext(new AutoCompleteUpdateEvent(itemToRemoveOrReAdd, TripAutoCompleteField.Comment, position));
-                } else {
-                    _unHideAutoCompleteVisibilityClicks.onNext(new AutoCompleteUpdateEvent(itemToRemoveOrReAdd, TripAutoCompleteField.CostCenter, position));
-                }
-            });
-            snackbar.show();
+            if (position >= 0 && position < resultsAdapter.getCount()) {
+                itemToRemoveOrReAdd = resultsAdapter.getItem(position);
+                resultsAdapter.remove(itemToRemoveOrReAdd);
+                resultsAdapter.notifyDataSetChanged();
+                View view = getActivity().findViewById(R.id.update_trip_layout);
+                snackbar = Snackbar.make(view, getString(
+                        R.string.item_removed_from_auto_complete, itemToRemoveOrReAdd.getDisplayName()), Snackbar.LENGTH_LONG);
+                snackbar.setAction(R.string.undo, v -> {
+                    if (nameBox.hasFocus()) {
+                        _unHideAutoCompleteVisibilityClicks.onNext(new AutoCompleteUpdateEvent(itemToRemoveOrReAdd, TripAutoCompleteField.Name, position));
+                    } else if (commentBox.hasFocus()) {
+                        _unHideAutoCompleteVisibilityClicks.onNext(new AutoCompleteUpdateEvent(itemToRemoveOrReAdd, TripAutoCompleteField.Comment, position));
+                    } else {
+                        _unHideAutoCompleteVisibilityClicks.onNext(new AutoCompleteUpdateEvent(itemToRemoveOrReAdd, TripAutoCompleteField.CostCenter, position));
+                    }
+                });
+                snackbar.show();
+            }
         });
     }
 


### PR DESCRIPTION
We have the most common issue at Crashlytics that occurs when some users try to remove an item from autocomplete list. Somehow they got -1 item's position to remove and the app crashes. 

I was not able to reproduce this bug on my side, so I added an additional validation for the item's position to cover this crash. 